### PR TITLE
Add project namespace in the notification display

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -242,7 +242,7 @@ export default {
 			return ''
 		},
 		getSubline(n) {
-			return this.getNotificationActionChar(n) + ' ' + n.project.path + this.getTargetIdentifier(n)
+			return this.getNotificationActionChar(n) + ' ' + n.project.path_with_namespace + this.getTargetIdentifier(n)
 		},
 		getTargetContent(n) {
 			return n.body


### PR DESCRIPTION
When working on multiple projects at the same time, it is very useful to also be able to see the project namespace in the notifications from Gitlab.

This commit will change the project name in the subline from:
- `project#123`
to
- `namespace/project#123`