### PR TITLE
Fix #51 when querying the todo api within Gitlab 15.5

### DIFF
--- a/lib/Service/GitlabAPIService.php
+++ b/lib/Service/GitlabAPIService.php
@@ -466,7 +466,7 @@ class GitlabAPIService {
 					foreach ($params as $key => $value) {
 						if (is_array($value)) {
 							foreach ($value as $oneArrayValue) {
-								$paramsContent .= $key . '[]=' . urlencode($oneArrayValue) . '&';
+								$paramsContent .= $key . urlencode($oneArrayValue) . '&';
 							}
 							unset($params[$key]);
 						}


### PR DESCRIPTION
The use of brackets is not necessary when constructing the parameters for querying the API.
In older version of Gitlab it worked without problems but it returns ``{"error":"action is invalid"}`` with Gitlab 15.5.

This pull request removes these brackets