### PR TITLE
fix(settings): Do not suggest wrong scope

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -15,7 +15,7 @@
 			<strong>{{ redirect_uri }}</strong>
 		</p>
 		<p class="settings-hint">
-			{{ t('integration_gitlab', 'Give "read_user", "read_api" and "read_repository" permissions to the application. Optionally "api" instead.') }}
+			{{ t('integration_gitlab', 'Give "read_user", "read_api" and "read_repository" permissions to the application.') }}
 		</p>
 		<p class="settings-hint">
 			{{ t('integration_gitlab', 'Put the "Application ID" and "Application secret" below. Your Nextcloud users will then see a "Connect to GitLab" button in their personal settings if they select the GitLab instance defined here.') }}

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -5,7 +5,7 @@
 			{{ t('integration_gitlab', 'GitLab integration') }}
 		</h2>
 		<p v-if="!showOAuth && !connected" class="settings-hint">
-			{{ t('integration_gitlab', 'When you create an access token yourself, give it at least "read_user", "read_api" and "read_repository" permissions. Optionally "api" instead.') }}
+			{{ t('integration_gitlab', 'When you create an access token yourself, give it at least "read_user", "read_api" and "read_repository" permissions.') }}
 		</p>
 		<div id="gitlab-content">
 			<div class="line">


### PR DESCRIPTION
Only giving api scope and nothing else does not work:
![image](https://github.com/nextcloud/integration_gitlab/assets/26026535/2fc93c25-c368-4f63-84c4-a611ab5b54b3)
It's also more secure to only give the required scopes, so this is better anyway.