### PR TITLE
3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.1.1 – 2024-08-30
+
+### Fixed
+
+- userId can be null in the service (the reference provider can now be used in public contexts) (#97) @julien-nc
+- infer token_type in repair step (#98) @kyteinsky
+
+
 ## 3.1.0 – 2024-08-21
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <summary>Integration of GitLab software development management service</summary>
     <description><![CDATA[GitLab integration provides a dashboard widget displaying your most important notifications
     and a unified search provider for repositories, issues and merge requests.]]></description>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Gitlab</namespace>


### PR DESCRIPTION
## 3.1.1 – 2024-08-30

### Fixed

- userId can be null in the service (the reference provider can now be used in public contexts) (#97) @julien-nc
- infer token_type in repair step (#98) @kyteinsky
